### PR TITLE
Added constructor with only serial port

### DIFF
--- a/src/UBLOX.cpp
+++ b/src/UBLOX.cpp
@@ -25,9 +25,18 @@
 /* uBlox object, input the serial bus and baud rate */
 UBLOX::UBLOX(HardwareSerial& bus,uint32_t baud)
 {
-  _bus = &bus;
+	_bus = &bus;
 	_baud = baud;
 }
+
+/* uBlox object, input the serial bus */
+UBLOX::UBLOX(HardwareSerial& bus)
+{
+	_bus = &bus;
+	_baud = 0;
+	_parserState=0;
+}
+
 
 /* starts the serial communication */
 void UBLOX::begin()

--- a/src/UBLOX.h
+++ b/src/UBLOX.h
@@ -48,6 +48,7 @@ class UBLOX{
       FIXED_SOL
     };
     UBLOX(HardwareSerial& bus,uint32_t baud);
+    UBLOX(HardwareSerial& bus);
     void begin();
     bool readSensor();
     uint32_t getTow_ms();


### PR DESCRIPTION
This allows serial port to be controlled externally of UBLOX::begin().
For my program I have to run commands initially after opening the serial port before it is usable. Really it's just initializing _parserState and setting _baud to 0 since _baud isn't used anywhere else.