### PR TITLE
Optional possibility to define rx and tx pins on initialization

### DIFF
--- a/src/UBLOX.cpp
+++ b/src/UBLOX.cpp
@@ -23,10 +23,13 @@
 #include "UBLOX.h"
 
 /* uBlox object, input the serial bus and baud rate */
-UBLOX::UBLOX(HardwareSerial& bus,uint32_t baud)
+UBLOX::UBLOX(HardwareSerial& bus,uint32_t baud, uint32_t config, int8_t rxPin, int8_t txPin)
 {
-  _bus = &bus;
+	_bus = &bus;
 	_baud = baud;
+	_config = config;
+	_rxPin = rxPin;
+	_txPin = txPin;
 }
 
 /* starts the serial communication */
@@ -35,7 +38,7 @@ void UBLOX::begin()
 	// initialize parsing state
 	_parserState = 0;
 	// begin the serial port for uBlox
-	_bus->begin(_baud);
+	_bus->begin(_baud, _config, _rxPin, _txPin);
 }
 
 /* reads packets from the uBlox receiver */

--- a/src/UBLOX.h
+++ b/src/UBLOX.h
@@ -47,7 +47,7 @@ class UBLOX{
       FLOAT_SOL,
       FIXED_SOL
     };
-    UBLOX(HardwareSerial& bus,uint32_t baud);
+    UBLOX(HardwareSerial& bus,uint32_t baud, uint32_t config=SERIAL_8N1, int8_t rxPin=-1, int8_t txPin=-1);
     void begin();
     bool readSensor();
     uint32_t getTow_ms();
@@ -108,6 +108,9 @@ class UBLOX{
   private:
     HardwareSerial* _bus;
     uint32_t _baud;
+    uint32_t _config;
+    uint8_t _rxPin;
+    uint8_t _txPin;
   	uint8_t _parserState;
     const uint8_t _ubxHeader[2] = {0xB5, 0x62};
     const uint8_t _ubxNavPvt_msgClass = 0x01;


### PR DESCRIPTION
This is useful for ESP devices that have serial GPS devices connected to non-standard pins (i.e TTGO T-Beam). It is possible to initialize and use these devices without separate calls to Serial.begin().