### PR TITLE
Remove invalid item from depends field of library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Sensors
 url=https://github.com/bolderflight/ublox
 architectures=*
 includes=ubx.h
-depends=Bolder Flight Systems Units, Bolder Flight Systems Eigen
+depends=Bolder Flight Systems Eigen


### PR DESCRIPTION
The `depends` field of [the library.properties metadata file](https://arduino.github.io/arduino-cli/latest/library-specification/#libraryproperties-file-format) specifies the dependencies that should be installed along with
the library by the [Arduino Library Manager](https://docs.arduino.cc/software/ide-v1/tutorials/installing-libraries#using-the-library-manager).

This field must contain only the names of libraries that are available for installation via Library Manager.

The presence of any items which are not in Library Manager causes installation of the library to fail:

- [Arduino IDE 1.x](https://github.com/arduino/Arduino): "`no protocol:`" error
- [Arduino IDE 2.x](https://github.com/arduino/arduino-ide): fails silently ([`arduino/arduino-ide#621`](https://github.com/arduino/arduino-ide/issues/621))
- [Arduino CLI](https://arduino.github.io/arduino-cli/latest/): "`No valid dependencies solution found`" error

---

My guess is that this was intended to be [`Bolder Flight Systems Unit Conversions`](https://github.com/bolderflight/units/blob/v4.2.1/library.properties#L1). However, I was not able to verify this because I found the "**Bolder Flight Systems UBLOX**" library and [its example sketch](https://github.com/bolderflight/ublox/tree/main/examples/arduino/ublox_example) don't have any dependencies on other Arduino libraries. For this reason, I opted to remove the invalid item from the `depends` field entirely instead of correcting the name.

---

Originally reported at https://forum.arduino.cc/t/external-library-wont-install-using-library-manager/1127278